### PR TITLE
fix java.lang.NoSuchMethodError: No interface method startReplaceable…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,15 @@
 buildscript {
     ext{
         android_gradle_plugin_version = '4.1.2'
-        kotlin_version = "1.5.10"
+        // java.lang.NoSuchMethodError: No interface method startReplaceableGroup(ILjava/lang/String;)
+        // V in class Landroidx/compose/runtime/Composer;
+        // kotlin_version = "1.5.10"
+        kotlin_version = "1.4.32"
         coroutines_version = '1.4.3'
-        compose_version = '1.0.0-beta08'//1.0.0-alpha07  /1.0.0-beta06
+        // java.lang.NoSuchMethodError: No interface method startReplaceableGroup(ILjava/lang/String;)
+        // V in class Landroidx/compose/runtime/Composer;
+        // compose_version = '1.0.0-beta08'//1.0.0-alpha07  /1.0.0-beta06
+        compose_version = '1.0.0-beta06'
         compose_activity_version = '1.3.0-alpha07'   // 1.3.0-alpha04 1.3.0-alpha05 1.3.0-alpha07 1.3.0-alpha08 1.3.0-beta01
         compose_appcompat_version = '1.3.0'   // 1.3.0-beta01  1.4.0-alpha02 //https://www.wanandroid.com/maven_pom/index?k=androidx.appcompat
         compose_constraintlayout_version = '1.0.0-alpha07'//1.0.0-alpha07


### PR DESCRIPTION
fix java.lang.NoSuchMethodError: No interface method startReplaceableGroup(ILjava/lang/String;)V in class Landroidx/compose/runtime/Composer; or its super classes (declaration of 'androidx.compose.runtime.Composer' appears in /data/app/com.ellison.composemovie-ay3hzie4VwOnMmpEsYG9wA==/base.apk)